### PR TITLE
Fix for using typeahead with 'valueKey' property

### DIFF
--- a/bootstrap-tokenfield/bootstrap-tokenfield.js
+++ b/bootstrap-tokenfield/bootstrap-tokenfield.js
@@ -127,8 +127,8 @@
     constructor: Tokenfield
 
   , createToken: function (attrs) {
-      if (typeof attrs === 'string') {
-        attrs = { value: attrs, label: attrs }
+      if (!('label' in attrs)) {
+        attrs = { value: attrs.value, label: attrs.value }
       }
       
       var _self = this
@@ -330,7 +330,7 @@
           return false
         })
         .on('typeahead:selected', function (e, datum) {
-          _self.createToken( datum.value )
+          _self.createToken( datum )
           _self.$input.typeahead('setQuery', '')
           if (_self.$input.data( 'edit' )) {
             _self.unedit(true)


### PR DESCRIPTION
For twitter typehead a 'valueKey' may be passed in to chose the value to
be used in the suggestions. This key/value set was not being passed in
to 'createToken', resulting in 'createToken' to fail. (createToken was
checking for a 'string' type, however the index may be an 'integer').
