### PR TITLE
RequireJS AMD support

### DIFF
--- a/bootstrap-tokenfield/bootstrap-tokenfield.js
+++ b/bootstrap-tokenfield/bootstrap-tokenfield.js
@@ -5,7 +5,13 @@
  * Copyright 2013 Sliptree
  * ============================================================ */
 
-!function ($) {
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define(['jquery'], factory);
+  } else {
+    root.Tokenfield = factory(root.jQuery);
+  }
+}(this, function ($) {
 
   "use strict"; // jshint ;_;
 
@@ -887,4 +893,6 @@
     return this
   }
 
-}(window.jQuery);
+  return Tokenfield;
+
+}));


### PR DESCRIPTION
This commit enables Tokenfield as AMD module.
Example:

``` javascript
require(['jquery', 'bootstrap-tokenfield'], function ($) {
    $('input').tokenfield();
});
```
