### PR TITLE
fixed issue where tokens with numeric values wouldn't be flagged as dupl...

### DIFF
--- a/bootstrap-tokenfield/bootstrap-tokenfield.js
+++ b/bootstrap-tokenfield/bootstrap-tokenfield.js
@@ -270,7 +270,7 @@
       var data = token.map(function() {
         var $token = $(this);
         return {
-          value: $token.data('value') || $token.find('.token-label').text(),
+          value: $token.attr('data-value') || $token.find('.token-label').text(),
           label: $token.find('.token-label').text()
         }
       }).get();


### PR DESCRIPTION
I fixed this in my local copy, but wanted to share for everyone's benefit.

You can currently enter values like "1" or ".01" multiple times even with allowDuplicates set to false.

The issue is that $.data() function is used in getTokenData to get the value stored on the token.  $.data() will always convert the value into a JavaScript datatype based on the content stored.  Thus, if "1" is stored, it will pull it in as 1 numeric instead of string "1".  When $.grep() is run against this value vs. the string value being entered, it will never match, thus permitting the duplicate.

Fix:  In getTokenData function on line 273, change $token.data('value') to $token.attr('data-value') so that it always gets the string representation of the value.

Thanks for this great plugin!
