### PR TITLE
Disable typeahead hint

### DIFF
--- a/js/bootstrap-tokenfield.js
+++ b/js/bootstrap-tokenfield.js
@@ -165,7 +165,7 @@
     // Initialize typeahead, if necessary
     if ( ! $.isEmptyObject( this.options.typeahead ) ) {
       var typeaheadOptions = $.extend({}, this.options.typeahead, {})
-      this.$input.typeahead( null, typeaheadOptions )
+      this.$input.typeahead( { hint: false }, typeaheadOptions )
       this.typeahead = true
     }
 


### PR DESCRIPTION
After adding the first token, the typeahead hint gets positioned above existing token which looks funny and doesn't make sense. disabling it.
