### PR TITLE
Support readonly inputs

### DIFF
--- a/js/bootstrap-tokenfield.js
+++ b/js/bootstrap-tokenfield.js
@@ -134,6 +134,11 @@
       this.disable();
     }
 
+    // Set tokenfield readonly, if original input is readonly
+    if (this.$element.prop('readonly')) {
+      this.readonly();
+    }
+
     // Set up mirror for input auto-sizing
     this.$mirror = $('<span style="position:absolute; top:-999px; left:0; white-space:pre;"/>');
     this.$input.css('min-width', this.options.minWidth + 'px')
@@ -280,11 +285,11 @@
       // Listen to events
       token
         .on('mousedown',  function (e) {
-          if (_self.disabled) return false;
+          if (_self.disabled || _self.readonly) return false;
           _self.preventDeactivation = true
         })
         .on('click',    function (e) {
-          if (_self.disabled) return false;
+          if (_self.disabled || _self.readonly) return false;
           _self.preventDeactivation = false
 
           if (e.ctrlKey || e.metaKey) {
@@ -295,7 +300,7 @@
           _self.activate( token, e.shiftKey, e.shiftKey )          
         })
         .on('dblclick', function (e) {
-          if (_self.disabled || !_self.options.allowEditing ) return false;
+          if (_self.disabled || _self.readonly || !_self.options.allowEditing ) return false;
           _self.edit( token )
         })
 
@@ -827,7 +832,7 @@
     }
 
   , remove: function (e, direction) {
-      if (this.$input.is(document.activeElement) || this.disabled) return
+      if (this.$input.is(document.activeElement) || this.disabled || this.readonly) return
 
       var token = (e.type === 'click') ? $(e.target).closest('.token') : this.$wrapper.find('.token.active')
       
@@ -928,6 +933,20 @@
       this.$input.prop('disabled', false);
       this.$element.prop('disabled', false);
       this.$wrapper.removeClass('disabled');
+    }
+
+  , readonly: function () {
+      this.readonly = true;
+      this.$input.prop('readonly', true);
+      this.$element.prop('readonly', true);
+      this.$wrapper.removeClass('readonly');
+    }
+
+  , writeable: function () {
+      this.readonly = false;
+      this.$input.prop('readonly', false);
+      this.$element.prop('readonly', false);
+      this.$wrapper.removeClass('readonly');
     }
 
   , destroy: function() {


### PR DESCRIPTION
Is there any reason why there's no support for readonly inputs?
It'd be nice if the plugin supported them the same way it does for disabled inputs/fieldsets, see the patch for example (no tests yet).
