### PR TITLE
Test minLength against label

### DIFF
--- a/js/bootstrap-tokenfield.js
+++ b/js/bootstrap-tokenfield.js
@@ -203,7 +203,7 @@
         , value = $.trim(attrs.value)
         , label = attrs.label && attrs.label.length ? $.trim(attrs.label) : value
 
-      if (!value.length || !label.length || value.length < this.options.minLength) return
+      if (!value.length || !label.length || label.length <= this.options.minLength) return
 
       if (this.options.limit && this.getTokens().length >= this.options.limit) return
 


### PR DESCRIPTION
Returns only if the label length is smaller or equal to the minLength option.
