### PR TITLE
Always pass datum on typeahead events

### DIFF
--- a/js/bootstrap-tokenfield.js
+++ b/js/bootstrap-tokenfield.js
@@ -431,20 +431,13 @@
           }
           return false
         })
-        .on('typeahead:selected', function (e, datum, dataset) {
+        .on('typeahead:selected typeahead:autocompleted', function (e, datum, dataset) {
           // Create token
           if (_self.createToken( datum )) {
             _self.$input.typeahead('val', '')
             if (_self.$input.data( 'edit' )) {
               _self.unedit(true)
             }
-          }
-        })
-        .on('typeahead:autocompleted', function (e, datum, dataset) {
-          _self.createToken( _self.$input.val() )
-          _self.$input.typeahead('val', '')
-          if (_self.$input.data( 'edit' )) {
-            _self.unedit(true)
           }
         })
 


### PR DESCRIPTION
This partially solve #114, for the typeahead part... The code on both event (selected and autocompleted) was nearly the same.  So my suggestion is to merge both.
