### PR TITLE
Use schemaless URLs for absolute-path assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,9 +14,9 @@ title: Tokenfield for Bootstrap
     <title>Tokenfield for Bootstrap</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css" rel="stylesheet">
+    <link href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css" rel="stylesheet">
     <!-- jQuery UI CSS -->
-    <link href="http://code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css" type="text/css" rel="stylesheet">
+    <link href="//code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css" type="text/css" rel="stylesheet">
     <!-- Bootstrap styling for Typeahead -->
     <link href="dist/css/tokenfield-typeahead.css" type="text/css" rel="stylesheet">
     <!-- Tokenfield CSS -->
@@ -633,8 +633,8 @@ $('#tokenfield')
       </div>
     </footer>
 
-    <script type="text/javascript" src="http://code.jquery.com/jquery-1.9.1.js"></script>
-    <script type="text/javascript" src="http://code.jquery.com/ui/1.10.3/jquery-ui.js"></script>
+    <script type="text/javascript" src="//code.jquery.com/jquery-1.9.1.js"></script>
+    <script type="text/javascript" src="//code.jquery.com/ui/1.10.3/jquery-ui.js"></script>
     <script type="text/javascript" src="dist/bootstrap-tokenfield.js" charset="UTF-8"></script>   
     <script type="text/javascript" src="docs-assets/js/scrollspy.js" charset="UTF-8"></script>   
     <script type="text/javascript" src="docs-assets/js/affix.js" charset="UTF-8"></script>   


### PR DESCRIPTION
This should fix https://sliptree.github.io/bootstrap-tokenfield for users of https://www.eff.org/https-everywhere

cf.
https://stackoverflow.com/questions/4831741/can-i-change-all-my-http-links-to-just
