### PR TITLE
Allow all tokens to be removed

### DIFF
--- a/js/bootstrap-tokenfield.js
+++ b/js/bootstrap-tokenfield.js
@@ -316,8 +316,6 @@
     }    
 
   , setTokens: function (tokens, add, triggerChange) {
-      if (!tokens) return
-
       if (!add) this.$wrapper.find('.token').remove()
 
       if (typeof triggerChange === 'undefined') {


### PR DESCRIPTION
In the absence of a removeTokens method, allow all tokens to be removed using: 

`$('#myField').tokenfield('setToken, '');`
