### PR TITLE
Add option to disable pasting from clipboard

### DIFF
--- a/js/bootstrap-tokenfield.js
+++ b/js/bootstrap-tokenfield.js
@@ -25,7 +25,7 @@
       };
   } else {
     // Browser globals
-    factory(jQuery);
+    factory(jQuery, window);
   }
 }(function ($, window) {
 


### PR DESCRIPTION
Add option to disable pasting from clipboard.

Use case where you only want data from auto complete or typeahead to be created as a token.

Docs should also be updated with new options.
