### PR TITLE
Define $element.data('bs.tokenfield') earlier.

### DIFF
--- a/js/bootstrap-tokenfield.js
+++ b/js/bootstrap-tokenfield.js
@@ -37,7 +37,8 @@
   var Tokenfield = function (element, options) {
     var _self = this
 
-    this.$element = $(element)
+    this.$element = $(element);
+    this.$element.data('bs.tokenfield', _self);
     this.textDirection = this.$element.css('direction');
 
     // Extend options
@@ -992,7 +993,7 @@
         value = data[option].apply(data, args)
       } else {
         if (!data && typeof option !== 'string' && !param) {
-          $this.data('bs.tokenfield', (data = new Tokenfield(this, options)))
+          data = new Tokenfield(this, options);
           $this.trigger('tokenfield:initialize')
         }
       }


### PR DESCRIPTION
Define `$element.data('bs.tokenfield')` at the beginning of `Tokenfield()` instead of after initialization so the Tokenfield object is also available through `$(this).data('bs.tokenfield')` in events triggered during initialization. This is useful when `tokenfield:createtoken` or `tokenfield:createdtoken` events have been attached before initialization, so they are run on page load if the tokenfield input has a default value on page load.

Before this fix you would get an error if you tried to use `$(this).data('bs.tokenfield').$input` inside a `tokenfield:createtoken` event that was bound before tokenfield initialization like this

``` javascript
$('#tokenfield')
    .on('tokenfield:createtoken', function(){
        var $input = $(this).data('bs.tokenfield').$input;
        // Do something with $input
    })
    .tokenfield()
```

You could just bind the event after `.tokenfield()` but then the create event would not be run on initialization (on page load)  when tokens are created from the default value attribute of the `#tokenfield` input.

Before this fix you could use a workaround of recreating the tokens after initialization to fire the create events like so `$('#tokenfield').tokenfield('setTokens', $('#tokenfield').tokenfield('getTokens'));` but this is not needed anymore after this commit.
