### PR TITLE
Make sure to display the correct label.

### DIFF
--- a/js/bootstrap-tokenfield.js
+++ b/js/bootstrap-tokenfield.js
@@ -335,8 +335,17 @@
       }
 
       var _self = this
+      var typeaheadOptions = this.options.typeahead[1]
+
       $.each(tokens, function (i, attrs) {
-        _self.createToken(attrs, triggerChange)
+        if ( ! $.isEmptyObject( typeaheadOptions ) ) {
+          typeaheadOptions.source(attrs, function(value) {
+            _self.createToken(value[0], triggerChange)
+          });
+        }
+        else {
+          _self.createToken(attrs, triggerChange)
+        }
       })
 
       return this.$element.get(0)


### PR DESCRIPTION
This was originally logged as issue #142.

If a form is submitted and the user navigates back to the page, the value would be displayed instead of the label. This resolves the issue by submitting the value to Typeahead which then returns the correct
values.
