### PR TITLE
Set length of hint input if using Typeahead.

### DIFF
--- a/dist/bootstrap-tokenfield.js
+++ b/dist/bootstrap-tokenfield.js
@@ -192,6 +192,7 @@
       args[0] = $.extend( {}, defaults, args[0] )
 
       this.$input.typeahead.apply( this.$input, args )
+      this.$hint = this.$input.prev()
       this.typeahead = true
     }
   }
@@ -882,6 +883,10 @@
         }
 
         this.$input.width( mirrorWidth )
+
+        if (this.$hint) {
+          this.$hint.width( mirrorWidth )
+        }
       }
       else {
         var w = (this.textDirection === 'rtl')
@@ -892,6 +897,10 @@
         // dimensions returned by jquery will be NaN -> we default to 100%
         // so placeholder won't be cut off.
         isNaN(w) ? this.$input.width('100%') : this.$input.width(w);
+
+        if (this.$hint) {
+          isNaN(w) ? this.$hint.width('100%') : this.$hint.width(w);
+        }
       }
     }
 

--- a/dist/bootstrap-tokenfield.js
+++ b/dist/bootstrap-tokenfield.js
@@ -192,7 +192,7 @@
       args[0] = $.extend( {}, defaults, args[0] )
 
       this.$input.typeahead.apply( this.$input, args )
-      this.$hint = this.$input.prev()
+      this.$hint = this.$input.prev('.tt-hint')
       this.typeahead = true
     }
   }


### PR DESCRIPTION
This should resolve issue #161. 

Added a reference to the hint field if using Typeahead and update the width of the hint field when executing the 'update' function.