### PR TITLE
Add setTimeout to correctly resize after createToken command.

### DIFF
--- a/js/bootstrap-tokenfield.js
+++ b/js/bootstrap-tokenfield.js
@@ -310,7 +310,10 @@
       }
 
       // Update tokenfield dimensions
-      this.update()
+      var _self = this
+      setTimeout(function () {
+        _self.update()
+      }, 0)
 
       // Return original element
       return this.$element.get(0)


### PR DESCRIPTION
Inner input was resizing before new token was added to the DOM. Added a setTimeout to fix.