### PR TITLE
Fix tokenfield input resize

### DIFF
--- a/js/bootstrap-tokenfield.js
+++ b/js/bootstrap-tokenfield.js
@@ -887,6 +887,9 @@
         this.$input.width( mirrorWidth )
       }
       else {
+        //temporary reset width to minimal value to get proper results
+        this.$input.width(this.options.minWidth);
+        
         var w = (this.textDirection === 'rtl')
               ? this.$input.offset().left + this.$input.outerWidth() - this.$wrapper.offset().left - parseInt(this.$wrapper.css('padding-left'), 10) - inputPadding - 1
               : this.$wrapper.offset().left + this.$wrapper.width() + parseInt(this.$wrapper.css('padding-left'), 10) - this.$input.offset().left - inputPadding;


### PR DESCRIPTION
By temporarily changing the input width to minimal value we can correclty calculate the width available in tokenfield container.

Fixes #211 

Additionally I didn't knew if it should be a part of fix or not but I would change:

```javacsript
isNaN(w) ? this.$input.width('100%') : this.$input.width(w);
```

to: 

```javascript
w = isNaN(w) ? '100%' : w;
this.$input.width(w);
```

or even 

```javascript
this.$input.width( isNaN(w) ? '100%' : w );
```
in order to keep functions DRY