### PR TITLE
Added a 'setInput' method to allow the input value to be modified.

### DIFF
--- a/js/bootstrap-tokenfield.js
+++ b/js/bootstrap-tokenfield.js
@@ -383,6 +383,16 @@
   , getInput: function() {
     return this.$input.val()
   }
+      
+  , setInput: function (val) {
+      if (this.$input.hasClass('tt-input')) {
+          // Typeahead acts weird when simply setting input value to empty,
+          // so we set the query to empty instead
+          this.$input.typeahead('val', val)
+      } else {
+          this.$input.val(val)
+      }
+  }
 
   , listen: function () {
       var _self = this
@@ -648,13 +658,7 @@
       if (tokensBefore == this.getTokensList() && this.$input.val().length)
         return false // No tokens were added, do nothing (prevent form submit)
 
-      if (this.$input.hasClass('tt-input')) {
-        // Typeahead acts weird when simply setting input value to empty,
-        // so we set the query to empty instead
-        this.$input.typeahead('val', '')
-      } else {
-        this.$input.val('')
-      }
+      this.setInput('')
 
       if (this.$input.data( 'edit' )) {
         this.unedit(focus)


### PR DESCRIPTION
Adding to the example for preventing duplicate token creation I wanted to be able to clear out the input field rather than leave the value there.

This patch allows this ability to set clear the value out if you want to.

    $('#my-tokenfield').on('tokenfield:createtoken', function (event) {
        var existingTokens = $(this).tokenfield('getTokens');
        $.each(existingTokens, function(index, token) {
            if (token.value === event.attrs.value)
                event.preventDefault();
                $(this).tokenfield('setInput', '');
        });
    });