### PR TITLE
Add label option for custom tag content

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,6 +211,12 @@ $('.tokenfield').tokenfield()
                       <td>Whether to insert spaces after each token when getting a comma-separated list of tokens. This affects both value returned by <code>getTokensList()<code> and the value of the original input field.</td>
                     </tr>
                     <tr>
+                      <td>label</td>
+                      <td>function(attrs)</td>
+                      <td>returns <code>attrs.label</code> if exists, otherwise <code>attrs.value.trim()</code></td>
+                      <td>The template to use to generate the content inside tags.</td>
+                    </tr>
+                    <tr>
                       <td>inputType</td>
                       <td>string</td>
                       <td><code>'text'</code></td>

--- a/js/bootstrap-tokenfield.js
+++ b/js/bootstrap-tokenfield.js
@@ -216,7 +216,7 @@
 
       // Normalize label and value
       attrs.value = $.trim(attrs.value.toString());
-      attrs.label = attrs.label && attrs.label.length ? $.trim(attrs.label) : attrs.value
+      attrs.label = this.options.label(attrs);
 
       // Bail out if has no value or label, or label is too short
       if (!attrs.value.length || !attrs.label.length || attrs.label.length <= this.options.minLength) return
@@ -1023,6 +1023,9 @@
     createTokensOnBlur: false,
     delimiter: ',',
     beautify: true,
+    label: function(attrs) {
+      return attrs.label && attrs.label.length ? $.trim(attrs.label) : attrs.value;
+    },
     inputType: 'text'
   }
 


### PR DESCRIPTION
I'm using `tokenfield` to create lists of users with profile pictures. When I add a user, I'd like the tag to include the user's profile picture.

I tried using `tokenfield:createtoken` to create a custom label at the time the tag was created, and that worked well when adding tokens in response to user input. However, when tags are added programatically -- for example, at creation time -- then `tokenfield:createtoken` is not run, so default tag content was used instead.

Rather than change the contract for `tokenfield:createtoken` to be called _any_ time a token is added -- maybe not a bad idea, but not backwards compatible -- I chose to add a `label` option which is used to generate label content any time any time a token is added. This works well for my application, so I thought I'd share it!
