### PR TITLE
add ".tt-menu" alternative to ".tt-dropdown-menu" to make compatible with typeahead.js v0.11.1

### DIFF
--- a/less/tokenfield-typeahead.less
+++ b/less/tokenfield-typeahead.less
@@ -86,7 +86,7 @@
   font-size: 18px;
   line-height: 1.33;
 }
-.tt-dropdown-menu {
+.tt-dropdown-menu, .tt-menu {
   width: 100%;
   min-width: 160px;
   margin-top: 2px;


### PR DESCRIPTION
Can't find a ref in typeahead.js, but other libs are fixing this too: https://github.com/hyspace/typeahead.js-bootstrap3.less/issues/22

...and it fixed a display issue (menu styles not displaying) for me as well.

I could compile it... not sure on your contributor guidelines as they apply to CSS.

Thanks for the great lib, and happy to adjust PR or provide more explanation if it's helpful!