### PR TITLE
Use @token-active-border and @token-active-border-fallback

### DIFF
--- a/less/bootstrap-tokenfield.less
+++ b/less/bootstrap-tokenfield.less
@@ -91,8 +91,8 @@
       border-color: @token-hover-border;
     }
     &.active {
-      border-color: rgb(82, 168, 236);
-      border-color: rgba(82, 168, 236, 0.8);
+      border-color: @token-active-border-fallback;
+      border-color: @token-active-border;
     }
     &.duplicate {
       border-color: @state-danger-border;


### PR DESCRIPTION
WAS: @token-active-border and @token-active-border-fallback LESS-variables was defined but not in using.
IS: The variables has used for token border color when token state is active.